### PR TITLE
修复被控端打开多个端口且允许多个用户时，仅第一个参数生效的Bug

### DIFF
--- a/src/P2PSocekt.Core/Utils/BinaryUtils.cs
+++ b/src/P2PSocekt.Core/Utils/BinaryUtils.cs
@@ -165,11 +165,21 @@ namespace P2PSocket.Core.Utils
         public static List<T> ReadObjectList<T>(BinaryReader handle) where T : IObjectToString
         {
             List<T> retList = new List<T>();
-            if (ReadInt(handle) > 0)
+            //if (ReadInt(handle) > 0)
+            //{
+                //IObjectToString instance = Activator.CreateInstance(typeof(T)) as IObjectToString;
+                //instance.ToObject(ReadString(handle));
+              //retList.Add((T)instance);
+            //}
+            //这里是用于被控端打开多端口时，读取配置信息，上面那种写法会导致只读取第一个，
+            //而多端口应该把多个AllowPortItem信息发送给服务端
+            int index = ReadInt(handle);
+            while (index > 0)
             {
                 IObjectToString instance = Activator.CreateInstance(typeof(T)) as IObjectToString;
                 instance.ToObject(ReadString(handle));
                 retList.Add((T)instance);
+                index--;
             }
             return retList;
         }


### PR DESCRIPTION
ReadObjectList<T>方法，这里是用于被控端打开多端口时，读取被控端发送的P2PSocket.Client.Global.AllowPortList并将其写入到P2PSocket.Server.Global.TcpMap中，上面被注释掉的那种写法会导致只读取第一个值，而多端口应该把多个AllowPortItem信息发送给服务端